### PR TITLE
fix(options-page): reset button is working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "branch-name-from-jira-issue",
-  "version": "0.11.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "branch-name-from-jira-issue",
-      "version": "0.11.1",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-name-from-jira-issue",
-  "version": "0.11.2",
+  "version": "1.0.0",
   "description": "Generates a name for a git branch based on the the Jira Issue you're currently viewing in your browser.",
   "scripts": {
     "test": "exit 0",

--- a/src/components/OptionsButton/OptionsButton.tsx
+++ b/src/components/OptionsButton/OptionsButton.tsx
@@ -5,14 +5,15 @@ import { ButtonContainer, ButtonLabel } from './OptionsButton.styled';
 type OptionsButtonProps = {
   sectionLabel?: string;
   buttonLabel: string;
+  onClick: () => void;
 };
 
-const OptionsButton = ({ sectionLabel, buttonLabel }: OptionsButtonProps) => (
+const OptionsButton = ({ sectionLabel, buttonLabel, onClick }: OptionsButtonProps) => (
   <ButtonContainer>
     <ButtonLabel>
       <span>{sectionLabel}</span>
     </ButtonLabel>
-    <Button type="submit">
+    <Button onClick={onClick}>
       <span>{buttonLabel}</span>
     </Button>
   </ButtonContainer>

--- a/src/pages/options/OptionsPage.tsx
+++ b/src/pages/options/OptionsPage.tsx
@@ -30,7 +30,7 @@ const updateOption = (stateSetter: Function, optionName: string, optionValue: an
 };
 
 const updateOptionHandler = (stateSetter: Function, optionName: string, isCheckbox = false):
-    FormEventHandler<HTMLInputElement> => (event: ChangeEvent<HTMLInputElement>) => {
+  FormEventHandler<HTMLInputElement> => (event: ChangeEvent<HTMLInputElement>) => {
   try {
     let optionValue;
     if (isCheckbox) {
@@ -55,7 +55,14 @@ const OptionPage = () => {
   const [useConventionalPrefix, setUseConventionalPrefix] = useState(false);
   const [addGitCommand, setAddGitCommand] = useState(false);
   const [maxBranchLength, setMaxBranchLength] = useState<number>();
-  const [customPrefixes, setCustomPrefixes] = useState<string []>([]);
+  const [customPrefixes, setCustomPrefixes] = useState<string[]>([]);
+
+  const resetAllOptions = () => {
+    updateOption(setAddGitCommand, 'addGitCommand', false);
+    updateOption(setMaxBranchLength, 'maxBranchLength', '');
+    updateOption(setUseConventionalPrefix, 'enableConventionalPrefix', false);
+    updateOption(setCustomPrefixes, 'customPrefixes', []);
+  };
 
   useEffect(() => {
     chrome.runtime.sendMessage({ type: MessageTypes.GET_OPTIONS_REQUEST },
@@ -97,7 +104,7 @@ const OptionPage = () => {
               {' '}
               when copying to clipboard
             </>
-)}
+          )}
         />
         <InputNumber
           label={(
@@ -108,11 +115,11 @@ const OptionPage = () => {
               {' '}
               characters
             </>
-)}
+          )}
           value={maxBranchLength}
           onChange={updateOptionHandler(setMaxBranchLength, 'maxBranchLength')}
         />
-        <OptionsButton sectionLabel="Reset to defaults" buttonLabel="Reset" />
+        <OptionsButton onClick={() => resetAllOptions()} sectionLabel="Reset to defaults" buttonLabel="Reset" />
       </OptionsSection>
 
       <OptionsSection title="Prefixes">
@@ -134,7 +141,7 @@ const OptionPage = () => {
                 improve-readme
               </InlineCode>
             </>
-)}
+          )}
         />
         <MultiValueSelect
           options={customPrefixes}


### PR DESCRIPTION
The reset button in the Options page is now working as expected,
    resetting all the options to their original values